### PR TITLE
add define server

### DIFF
--- a/code/5_control_flow_analysis/5.2_best_practice.py
+++ b/code/5_control_flow_analysis/5.2_best_practice.py
@@ -69,6 +69,7 @@ def main(unused_argv):
       "ps": ps_spec,
       "worker": worker_spec})
   
+  server = tf.train.Server(cluster, job_name=FLAGS.job_name, task_index=FLAGS.task_index)
   # 如果是ps，直接启动服务，并开始监听worker发起的请求
   if FLAGS.job_name == "ps":
       server.join()


### PR DESCRIPTION
### 问题描述：
在实践5.2_best_practice.py的分布式代码当中，发现第74行的server未定义（书中也没有定义），导致运行时中出现server未定义的错误。

### 解决办法：
翻阅书本发现，在讲创建tensorflow集群时，有过`server = tf.train.Server(cluster, job_name=FLAGS.job_name, task_index=FLAGS.task_index)`的定义，而5.2_best_practice.py里并没有。自己尝试加上之后，PS作业无异常。

### 其他：
小小更正，也算不上什么大错误，书中的代码PS都是大写，而5.2_best_practice.py中PS为小写，如果不仔细看代码就会出错。

之前在issue中提到过这个问题，但没人回复我。所以我在此向您提出了PR。